### PR TITLE
fix(ci): update permissions in Scorecard workflow for security events

### DIFF
--- a/.github/workflows/openssf_scorecard.yml
+++ b/.github/workflows/openssf_scorecard.yml
@@ -9,7 +9,9 @@ on:
   push:
     branches: [ main ]
 
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   analysis:


### PR DESCRIPTION
# PR Summary

Update the permissions used in the GIthub Actions workflow used for OpenSSF scans. The updates narrow the scope to exclude permissions it doesn't need, while also adding the `security-event` permission it requires to upload issues via SARIF files.