### PR TITLE
Fix(Metadata Match): Missed Artifact Naming Format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/plexer_cli/const.py
+++ b/src/plexer_cli/const.py
@@ -4,5 +4,9 @@ Plexer - Normalize media files for use with Plex Media Server
 Module: Const - collection of global variables used across the application
 """
 
-ARTIFACT_NAME_REGEX = r"^[ -~]+\([\d]{4}\) ?(\{[ -~]+\})?$"
+ARTIFACT_NAME_REGEX = r"^[ \-~]+\([\d]{4}\) ?(\{[ \-~]+\})?$"
+ARTIFACT_HEURISTICS_PATTERNS = {
+    "name": r"^(.+?)([\.\-\_\(\[][1|2])",  # anything before the first instance of commonly-used separators
+    "release_year": r"(19|20)([0-9]{2})",  # any 4 digit number between 1900 and 2099
+}
 METADATA_FILE_NAME = ".plexer"

--- a/src/plexer_cli/const.py
+++ b/src/plexer_cli/const.py
@@ -4,7 +4,7 @@ Plexer - Normalize media files for use with Plex Media Server
 Module: Const - collection of global variables used across the application
 """
 
-ARTIFACT_NAME_REGEX = r"^[ \-~]+\([\d]{4}\) ?(\{[ \-~]+\})?$"
+ARTIFACT_NAME_REGEX = r"^(.+) (\([\d]{4}\)) ?(\{edition-.+\})?$"
 ARTIFACT_HEURISTICS_PATTERNS = {
     "name": r"^(.+?)([\.\-\_\(\[][1|2])",  # anything before the first instance of commonly-used separators
     "release_year": r"(19|20)([0-9]{2})",  # any 4 digit number between 1900 and 2099

--- a/src/plexer_cli/file_manager.py
+++ b/src/plexer_cli/file_manager.py
@@ -216,3 +216,4 @@ class FileManager:
                     )
             else:
                 logger.info("file artifact found, processing")
+                # TODO: implement file artifact processing (e.g., renaming, moving, etc.)

--- a/src/plexer_cli/metadata.py
+++ b/src/plexer_cli/metadata.py
@@ -9,6 +9,8 @@ import re
 from logzero import logger
 from prompt_toolkit import PromptSession
 
+from .const import ARTIFACT_HEURISTICS_PATTERNS
+
 
 class Metadata:
     """
@@ -18,10 +20,6 @@ class Metadata:
     name = ""
     release_year = 1900
     metadata_found = False
-    heuristics_patterns = {
-        "name": r"^(.+?)([\_\(\[])",  # anything before the first instance of commonly-used separators
-        "release_year": r"(19|20)([0-9]{2})",  # any 4 digit number between 1900 and 2099
-    }
 
     def __init__(self, name="", release_year=1900) -> None:
         self.name = name
@@ -76,12 +74,12 @@ class Metadata:
 
         # perform basic heuristics
         ## NAME
-        possible_name = re.search(self.heuristics_patterns["name"], file_name)
+        possible_name = re.search(ARTIFACT_HEURISTICS_PATTERNS["name"], file_name)
         if possible_name:
             self.name = self.scrub_artifact_name(possible_name.group(1))
         ## RELEASE YEAR
         possible_release_year = re.findall(
-            self.heuristics_patterns["release_year"], file_name
+            ARTIFACT_HEURISTICS_PATTERNS["release_year"], file_name
         )
         if possible_release_year:
             # if multiple years are found, take the last one since it's more likely to be the correct value

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -100,8 +100,7 @@ class TestMetadata:
         result = metadata.do_heuristic_analysis(file_name)
 
         assert result is True
-        # Regex captures minimally before first underscore, so just "The"
-        assert metadata.name == "The"
+        assert metadata.name == "The Matrix"
         assert metadata.release_year == 1999
         assert metadata.metadata_found is True
 
@@ -110,6 +109,18 @@ class TestMetadata:
 
         # Use format that matches the pattern (name followed by separator)
         file_name = "Movie Title [2015] 1080p BluRay.mkv"
+        result = metadata.do_heuristic_analysis(file_name)
+
+        assert result is True
+        assert metadata.name == "Movie Title"
+        assert metadata.release_year == 2015
+        assert metadata.metadata_found is True
+
+    def test_do_heuristic_analysis_period_delimited(self, metadata):
+        """Test heuristic analysis with period-delimited file naming convention"""
+
+        # Use format that matches the pattern (name followed by separator)
+        file_name = "Movie.Title.2015.1080p.BluRay.mkv"
         result = metadata.do_heuristic_analysis(file_name)
 
         assert result is True


### PR DESCRIPTION
# PR Summary

Plexer now supports heuristic matching against `.` delimited artifacts.

## General Changes

- Matching pattern for artifact name has been updated to account for `.` characters as a delimiter
- Fixed issue with artifact regex
- Added/updated unit tests accordingly

## Related Issue(s)

Related to: #100
