### PR TITLE
Feat(CLI): Add CLI Argument to Toggle Renaming Media Files

### DIFF
--- a/src/plexer_cli/file_manager.py
+++ b/src/plexer_cli/file_manager.py
@@ -193,9 +193,7 @@ class FileManager:
                     )
                     video_metadata.prompt_user_for_metadata()
 
-                if video_metadata.metadata_found and (
-                    artifact.mime_type != "directory" and rename_files
-                ):
+                if video_metadata.metadata_found:
                     logger.info("renaming artifact based on gathered metadata")
                     artifact = self.rename_artifact(
                         artifact=artifact,

--- a/src/plexer_cli/file_manager.py
+++ b/src/plexer_cli/file_manager.py
@@ -146,6 +146,7 @@ class FileManager:
         dir_artifacts: list,
         # video_metadata=Metadata(),
         prompt_behavior="default",
+        rename_files=False,
         dry_run=False,
     ) -> None:
         """
@@ -192,7 +193,9 @@ class FileManager:
                     )
                     video_metadata.prompt_user_for_metadata()
 
-                if video_metadata.metadata_found:
+                if video_metadata.metadata_found and (
+                    artifact.mime_type != "directory" and rename_files
+                ):
                     logger.info("renaming artifact based on gathered metadata")
                     artifact = self.rename_artifact(
                         artifact=artifact,
@@ -207,7 +210,6 @@ class FileManager:
                     if new_dir_artifacts:
                         self.process_directory(
                             dir_artifacts=new_dir_artifacts,
-                            # video_metadata=video_metadata,
                             dry_run=dry_run,
                         )
                 else:

--- a/src/plexer_cli/main.py
+++ b/src/plexer_cli/main.py
@@ -83,7 +83,7 @@ def main():
     fm.process_directory(
         dir_artifacts=artifacts,
         prompt_behavior=cli_args.prompt,
-        rename_files=cli_args.rename_files,
+        rename_files=not cli_args.disable_file_rename,
         dry_run=cli_args.dry_run,
     )
     logger.info("artifact processing completed successfully")

--- a/src/plexer_cli/main.py
+++ b/src/plexer_cli/main.py
@@ -40,10 +40,9 @@ def fetch_cli_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--rename-files",
+        "--disable-file-rename",
         action="store_true",
-        default=False,
-        help="Toggle whether or not to rename the actual media files in the destination directory to match the source directory; if using Plex with subtitles, you may want to toggle this (default: False)",
+        help="Toggle to skip renaming the actual media files to match the parent directory; if using Plex with subtitles, you may want to toggle this as subtitles are searched based on filename",
     )
 
     parser.add_argument(

--- a/src/plexer_cli/main.py
+++ b/src/plexer_cli/main.py
@@ -40,6 +40,13 @@ def fetch_cli_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--rename-files",
+        action="store_true",
+        default=False,
+        help="Toggle whether or not to rename the actual media files in the destination directory to match the source directory; if using Plex with subtitles, you may want to toggle this (default: False)",
+    )
+
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Perform a trial run with no changes made",
@@ -77,6 +84,7 @@ def main():
     fm.process_directory(
         dir_artifacts=artifacts,
         prompt_behavior=cli_args.prompt,
+        rename_files=cli_args.rename_files,
         dry_run=cli_args.dry_run,
     )
     logger.info("artifact processing completed successfully")

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -217,6 +217,36 @@ class TestFileManager:
         # Verify the metadata file is still present
         assert os.path.exists(f"{preloaded_media_dir}/{METADATA_FILE_NAME}")
 
+    def test_process_file_disable_rename(self, file_mgr, preloaded_media_dir):
+        """Process the artifacts in preloaded media directory with file renaming disabled"""
+
+        pmd_artifacts = file_mgr.get_artifacts(tgt_dir=preloaded_media_dir)
+        prepped_pmd_artifacts = file_mgr.prep_artifacts(artifacts=pmd_artifacts)
+
+        # Get original file list
+        original_files = set(os.listdir(preloaded_media_dir))
+
+        # Process with file renaming disabled
+        file_mgr.process_directory(
+            dir_artifacts=prepped_pmd_artifacts,
+            prompt_behavior="none",
+            rename_files=False,
+            dry_run=False,
+        )
+
+        # Verify no files were modified, only directories
+        current_files = set(os.listdir(preloaded_media_dir))
+        assert original_files == current_files
+
+        # Next, test with file renaming enabled
+        # DEV NOTE: Disabled until file processing is implemented in process_directory()
+        # file_mgr.process_directory(
+        #     dir_artifacts=prepped_pmd_artifacts, prompt_behavior="none", rename_files=True, dry_run=False
+        # )
+
+        # current_files = set(os.listdir(preloaded_media_dir))
+        # assert original_files != current_files
+
     def test_process_directory_dry_run(self, file_mgr, preloaded_media_dir):
         """Process the artifacts in preloaded media directory in dry run mode"""
 


### PR DESCRIPTION
This update introduces a command-line argument to toggle the renaming of media files in the destination directory, allowing users to retain original filenames for better compatibility with subtitle databases. The argument improves clarity and integrates with the existing file processing functionality.

## General Changes

- Added a `--disable-file-rename` argument to the CLI for toggling file renaming.
- Updated the `process_directory` method to accept the new argument.
- Included a unit test to verify the behavior of the renaming toggle.

## Related Issue(s)

Related to: #101

